### PR TITLE
Allow searching in multiple cities

### DIFF
--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -182,15 +182,16 @@ class Doctolib(LoginBrowser):
         return True
 
     def find_centers(self, where):
-        self.centers.go(where=where, params={'ref_visit_motive_ids[]': '6970', 'ref_visit_motive_ids[]': '7005'})
+        for city in where:
+            self.centers.go(where=city, params={'ref_visit_motive_ids[]': '6970', 'ref_visit_motive_ids[]': '7005'})
 
-        for i in self.page.iter_centers_ids():
-            page = self.center_result.open(id=i, params={'limit': '4', 'ref_visit_motive_ids%5B%5D': '6970', 'ref_visit_motive_ids%5B%5D': '7005', 'speciality_id': '5494', 'search_result_format': 'json'})
-            # XXX return all pages even if there are no indicated availabilities.
-            #for a in page.doc['availabilities']:
-            #    if len(a['slots']) > 0:
-            #        yield page.doc['search_result']
-            yield page.doc['search_result']
+            for i in self.page.iter_centers_ids():
+                page = self.center_result.open(id=i, params={'limit': '4', 'ref_visit_motive_ids%5B%5D': '6970', 'ref_visit_motive_ids%5B%5D': '7005', 'speciality_id': '5494', 'search_result_format': 'json'})
+                # XXX return all pages even if there are no indicated availabilities.
+                #for a in page.doc['availabilities']:
+                #    if len(a['slots']) > 0:
+                #        yield page.doc['search_result']
+                yield page.doc['search_result']
 
     def get_patients(self):
         self.master_patient.go()
@@ -375,9 +376,10 @@ class Application:
         else:
             docto.patient = patients[0]
 
+        cities = args.city.lower().split(',')
         while True:
-            for center in docto.find_centers(args.city):
-                if center['city'].lower() != args.city:
+            for center in docto.find_centers(cities):
+                if center['city'].lower() not in cities:
                     continue
 
                 log('Trying to find a slot in %s', center['name_with_title'])


### PR DESCRIPTION
Since some small cities only have a single center, allow people to select multiple cities by separating them with comas