### PR TITLE
Use markdown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,33 @@
-                    DOCTOSHOTGUN
-                    ************
+# DOCTOSHOTGUN
 
 This script lets you automatically book a vaccine slot on Doctolib for today or
 tomorrow, following rules from the French Government.
 
 
-Python dependencies:
+## Python dependencies
 
-* woob
-* cloudscraper
-* dateutil
-* termcolor
+- woob
+- cloudscraper
+- dateutil
+- termcolor
+
+## How to use it
 
 Install dependencies:
 
-$ pip install -r requirements.txt
+```
+pip install -r requirements.txt
+```
 
-How to use it:
+Run:
 
-$ ./doctoshotgun.py CITY USERNAME [PASSWORD]
+```
+./doctoshotgun.py <city> <email> [password]
+```
 
 For example:
 
+```
 $ ./doctoshotgun.py paris roger.philibert@gmail.com
 Password:
 ::: Trying to find a slot in Centre de Vaccination Covid 19 - Ville de Paris
@@ -30,3 +36,4 @@ Password:
 ::: Booking for Roger Philibert...
 ::: Booking status: True
 ::: Booked!
+```


### PR DESCRIPTION
Use markdown format in `README` to display titles and code snippets nicely.

You can even copy code snippets using the copy button:

![image](https://user-images.githubusercontent.com/17952318/118704500-7c0e4280-b817-11eb-8db8-8684577382df.png)

## :point_right:  [Preview](https://github.com/bokub/doctoshotgun/blob/patch-1/README.md) :point_left: 