### PR TITLE
Manage Diacritic in cities names

### DIFF
--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -384,7 +384,7 @@ class Application:
 
         while True:
             for center in docto.find_centers(docto.remove_accents(args.city)):
-                if docto.remove_accents(center['city'].lower()) != docto.remove_accents(args.city):
+                if docto.remove_accents(center['city'].lower()) != docto.normalize(args.city):
                     continue
 
                 log('Trying to find a slot in %s', center['name_with_title'])

--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -383,8 +383,8 @@ class Application:
             docto.patient = patients[0]
 
         while True:
-            for center in docto.find_centers(docto.remove_accents(args.city)):
-                if docto.remove_accents(center['city'].lower()) != docto.normalize(args.city):
+            for center in docto.find_centers(docto.normalize(args.city)):
+                if docto.normalize(center['city']) != docto.normalize(args.city):
                     continue
 
                 log('Trying to find a slot in %s', center['name_with_title'])

--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -340,8 +340,6 @@ class Doctolib(LoginBrowser):
         log('Booking status: %s', self.page.doc['confirmed'])
 
         return self.page.doc['confirmed']
- 
-
 
 class Application:
     def main(self):

--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -198,7 +198,6 @@ class Doctolib(LoginBrowser):
 
         return self.page.get_patients()
     
-    #@staticmethod
     def normalize(self, string):
         nfkd = unicodedata.normalize('NFKD', string)
         normalized = u"".join([c for c in nfkd if not unicodedata.combining(c)])

--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -198,7 +198,8 @@ class Doctolib(LoginBrowser):
 
         return self.page.get_patients()
     
-    def normalize(string):
+    #@staticmethod
+    def normalize(self, string):
         nfkd = unicodedata.normalize('NFKD', string)
         normalized = u"".join([c for c in nfkd if not unicodedata.combining(c)])
         normalized = re.sub(r'\W', '-', normalized)

--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 import datetime
 import argparse
 import getpass
+import unicodedata
 
 from dateutil.parser import parse as parse_date
 from dateutil.relativedelta import relativedelta
@@ -196,6 +197,10 @@ class Doctolib(LoginBrowser):
         self.master_patient.go()
 
         return self.page.get_patients()
+    
+    def remove_accents(self, string):
+        nfkd = unicodedata.normalize('NFKD', string)
+        return u"".join([c for c in nfkd if not unicodedata.combining(c)])
 
 
     def try_to_book(self, center):
@@ -335,6 +340,8 @@ class Doctolib(LoginBrowser):
         log('Booking status: %s', self.page.doc['confirmed'])
 
         return self.page.doc['confirmed']
+ 
+
 
 class Application:
     def main(self):
@@ -376,8 +383,8 @@ class Application:
             docto.patient = patients[0]
 
         while True:
-            for center in docto.find_centers(args.city):
-                if center['city'].lower() != args.city:
+            for center in docto.find_centers(docto.remove_accents(args.city)):
+                if docto.remove_accents(center['city'].lower()) != docto.remove_accents(args.city):
                     continue
 
                 log('Trying to find a slot in %s', center['name_with_title'])

--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -198,9 +198,11 @@ class Doctolib(LoginBrowser):
 
         return self.page.get_patients()
     
-    def remove_accents(self, string):
+    def normalize(string):
         nfkd = unicodedata.normalize('NFKD', string)
-        return u"".join([c for c in nfkd if not unicodedata.combining(c)])
+        normalized = u"".join([c for c in nfkd if not unicodedata.combining(c)])
+        normalized = re.sub(r'\W', '-', normalized)
+        return normalized.lower()
 
 
     def try_to_book(self, center):


### PR DESCRIPTION
Manage characters like é à è on cities names... This char should be omited on doctolib URL but are presents on cities names in the json. Exemple : Arès

I didn't find how to be able to use town with - and/or ' char (like Saint-Médard-en-Jalles or Villenave-d'Ornon)