### PR TITLE
Draft: Keep trying to find bookings in case of 503 HTTP error

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,12 @@ Password:
 ::: Booking status: True
 ::: Booked!
 ```
+
+# Development
+
+## Running tests
+
+```
+ $ pip install -r requirements-dev.txt
+ $ pytest test_browser.py
+```

--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -16,7 +16,7 @@ from dateutil.relativedelta import relativedelta
 import cloudscraper
 from termcolor import colored
 
-from woob.browser.exceptions import ClientError
+from woob.browser.exceptions import ClientError, ServerError
 from woob.browser.browsers import LoginBrowser
 from woob.browser.url import URL
 from woob.browser.pages import JsonPage, HTMLPage
@@ -182,7 +182,13 @@ class Doctolib(LoginBrowser):
         return True
 
     def find_centers(self, where):
-        self.centers.go(where=where, params={'ref_visit_motive_ids[]': ['6970', '7005']})
+        try:
+            self.centers.go(where=where, params={'ref_visit_motive_ids[]': ['6970', '7005']})
+        except ServerError as e:
+            if e.response.status_code in [503]:
+                return None
+            else:
+                raise e
 
         for i in self.page.iter_centers_ids():
             page = self.center_result.open(id=i, params={'limit': '4', 'ref_visit_motive_ids[]': ['6970', '7005'], 'speciality_id': '5494', 'search_result_format': 'json'})

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+responses

--- a/test_browser.py
+++ b/test_browser.py
@@ -1,0 +1,44 @@
+import pytest
+import responses
+from woob.browser.exceptions import ServerError
+
+from doctoshotgun import Doctolib
+
+
+@responses.activate
+def test_find_centers_returns_503_should_continue(tmp_path):
+    """
+    Check that find_centers doesn't raise a ServerError in case of 503 HTTP response
+    """
+    docto = Doctolib("roger.phillibert@gmail.com", "1234", responses_dirname=tmp_path)
+    docto.BASEURL = "https://127.0.0.1"
+
+    responses.add(
+        responses.GET,
+        "https://127.0.0.1/vaccination-covid-19/Paris?ref_visit_motive_ids%5B%5D=6970&ref_visit_motive_ids%5B%5D=7005",
+        status=503
+    )
+
+    # this should not raise an exception
+    for _ in docto.find_centers("Paris"):
+        pass
+
+
+@responses.activate
+def test_find_centers_returns_502_should_fail(tmp_path):
+    """
+    Check that find_centers raises an error in case of non-whitelisted status code
+    """
+    docto = Doctolib("roger.phillibert@gmail.com", "1234", responses_dirname=tmp_path)
+    docto.BASEURL = "https://127.0.0.1"
+
+    responses.add(
+        responses.GET,
+        "https://127.0.0.1/vaccination-covid-19/Paris?ref_visit_motive_ids%5B%5D=6970&ref_visit_motive_ids%5B%5D=7005",
+        status=502
+    )
+
+    # this should raise an exception
+    with pytest.raises(ServerError):
+        for _ in docto.find_centers("Paris"):
+            pass


### PR DESCRIPTION
Attempt at fixing #21 

Not finished, I think there are other pages that could make the script fail. Draft PR for now.

For testing I added a `test_browser.py`  file that depends on pytest and [responses](https://github.com/getsentry/responses). If you prefer another way of mocking http responses, I can adapt the test.

Note that I haven't tested this in real conditions. I'm also not happy with how I handled the error; I'd be happy to make more changes if someone has suggestions.

Also we might want to `sleep()` for a longer duration in case there are too many errors.