### PR TITLE
avoid Keyerror : 'search_result'

### DIFF
--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -190,7 +190,10 @@ class Doctolib(LoginBrowser):
             #for a in page.doc['availabilities']:
             #    if len(a['slots']) > 0:
             #        yield page.doc['search_result']
-            yield page.doc['search_result']
+            try:
+                yield page.doc['search_result']
+            except KeyError:
+                pass
 
     def get_patients(self):
         self.master_patient.go()


### PR DESCRIPTION
Sometimes I get `keyerror : 'search_result'` while my script is running so I have to restart the script. I am not sure exactly why I get this error. It seems that sometimes Doctolib does not return the expected data.


This PR fixes that