### PR TITLE
Do not book slots if new patients are not allowed

### DIFF
--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -91,6 +91,9 @@ class CenterBookingPage(JsonPage):
     def find_motive(self, regex):
         for s in self.doc['data']['visit_motives']:
             if re.search(regex, s['name']):
+                if s['allow_new_patients'] == False:
+                    log('Motive %s not allowed for new patients at this center. Skipping vaccine...', s['name'], flush=True)
+                    return None
                 return s['id']
 
         return None


### PR DESCRIPTION
Fixes #65

This was the easiest way to identify motives that are not allowed for new patients at specific centers. As we are randomly querying doctors, I guess nearly all users are new patients so I don't see a need for a command line parameter. Let me know if you think differently.

```
$ ./doctoshotgun.py de koln my@email.com PASSWORD --dry-run --center "Praxis am Ebertplatz - Hausärzte | Infektiologen"
Starting to look for vaccine slots for John Doe between 2021-06-11 and 2021-06-18...
Vaccines: Pfizer, Moderna, Janssen
Country: de 
This may take a few minutes/hours, be patient!

Center Praxis am Ebertplatz - Hausärzte | Infektiologen:
Motive Erstimpfung Covid-19 (BioNTech-Pfizer) not allowed for new patients at this center. Skipping vaccine...
– Praxis am Ebertplatz...
  Vaccine Janssen... first slot not found :(
```