### PR TITLE
add an option to exclude a list of centers from the search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,17 @@ Run:
 Further optional arguments:
 
 ```
---center "<name>" [--center <name> …] : filter centers to only choose one from the provided list
--p <index>, --patient <index>         : select patient for which book a slot
--z, --pfizer                          : looking only for a Pfizer vaccine
--m, --moderna                         : looking only for a Moderna vaccine
--j, --janssen                         : looking only for a Janssen vaccine
--d, --debug                           : display debug information
--t <days>, --time-window <days>       : set how many next days the script look for slots
---start-date <DD/MM/YYYY>             : first date on which you want to book the first slot
---end-date <DD/MM/YYYY>               : last date on which you want to book the first slot
---dry-run                             : do not really book a slot
+--center "<name>" [--center <name> …]                 : filter centers to only choose one from the provided list
+--center-exclude "<name>" [--center-exclude <name> …] : exclude centers from search and booking
+-p <index>, --patient <index>                         : select patient for which book a slot
+-z, --pfizer                                          : looking only for a Pfizer vaccine
+-m, --moderna                                         : looking only for a Moderna vaccine
+-j, --janssen                                         : looking only for a Janssen vaccine
+-d, --debug                                           : display debug information
+-t <days>, --time-window <days>                       : set how many next days the script look for slots
+--start-date <DD/MM/YYYY>                             : first date on which you want to book the first slot
+--end-date <DD/MM/YYYY>                               : last date on which you want to book the first slot
+--dry-run                                             : do not really book a slot
 ```
 
 ### With Docker

--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -504,6 +504,7 @@ class Application:
         parser.add_argument('--patient', '-p', type=int, default=-1, help='give patient ID')
         parser.add_argument('--time-window', '-t', type=int, default=7, help='set how many next days the script look for slots (default = 7)')
         parser.add_argument('--center', '-c', action='append', help='filter centers')
+        parser.add_argument('--center-exclude', '-x', action='append', help='exclude centers')
         parser.add_argument('--start-date', type=str, default=None, help='first date on which you want to book the first slot (format should be DD/MM/YYYY)')
         parser.add_argument('--end-date', type=str, default=None, help='last date on which you want to book the first slot (format should be DD/MM/YYYY)')
         parser.add_argument('--dry-run', action='store_true', help='do not really book the slot')
@@ -588,6 +589,10 @@ class Application:
                     if args.center:
                         if center['name_with_title'] not in args.center:
                             logging.debug("Skipping center '%s'", center['name_with_title'])
+                            continue
+                    elif args.center_exclude:
+                        if center['name_with_title'] in args.center_exclude:
+                            logging.debug("Skipping center '%s' because it's excluded", center['name_with_title'])
                             continue
                     else:
                         if docto.normalize(center['city']) not in cities:


### PR DESCRIPTION
Sometimes a doctor only offers the vaccine to known patients but hasn't set up Doctolib accordingly.
With this new parameter you can exclude doctors/centers that you know won't accept your booking.