### PR TITLE
Aggregates Pattern - Doctolib Keys

### DIFF
--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -107,7 +107,7 @@ class CentersPage(HTMLPage):
             # JavaScript:
             # var t = (e = r()(e)).data("u")
             #     , n = atob(t.replace(/\s/g, '').split('').reverse().join(''));
-            
+
             import base64
             href = base64.urlsafe_b64decode(''.join(span.attrib['data-u'].split())[::-1]).decode()
             query = dict(parse.parse_qsl(parse.urlsplit(href).query))
@@ -121,7 +121,7 @@ class CentersPage(HTMLPage):
 
             if 'page' in query:
                 return int(query['page'])
-        
+
         return None
 
 class CenterResultPage(JsonPage):
@@ -547,9 +547,7 @@ class Doctolib(LoginBrowser):
 
         return self.page.doc['confirmed']
 
-
-class DoctolibDE(Doctolib):
-    BASEURL = 'https://www.doctolib.de'
+class DoctolibDE_KEYS(Doctolib):
     KEY_PFIZER = '6768'
     KEY_PFIZER_SECOND = '6769'
     KEY_PFIZER_THIRD = None
@@ -559,6 +557,12 @@ class DoctolibDE(Doctolib):
     KEY_JANSSEN = '7978'
     KEY_ASTRAZENECA = '7109'
     KEY_ASTRAZENECA_SECOND = '7110'
+
+
+class DoctolibDE(Doctolib):
+    BASEURL = 'https://www.doctolib.de'
+    DE_keys = DoctolibDE_KEYS
+
     vaccine_motives = {
         KEY_PFIZER: 'Pfizer',
         KEY_PFIZER_SECOND: 'Zweit.*Pfizer|Pfizer.*Zweit',

--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -577,9 +577,7 @@ class DoctolibDE(Doctolib):
     centers = URL(r'/impfung-covid-19-corona/(?P<where>\w+)', CentersPage)
     center = URL(r'/praxis/.*', CenterPage)
 
-
-class DoctolibFR(Doctolib):
-    BASEURL = 'https://www.doctolib.fr'
+class DoctolibFR_KEYS(Doctolib):
     KEY_PFIZER = '6970'
     KEY_PFIZER_SECOND = '6971'
     KEY_PFIZER_THIRD = '8192'
@@ -589,6 +587,11 @@ class DoctolibFR(Doctolib):
     KEY_JANSSEN = '7945'
     KEY_ASTRAZENECA = '7107'
     KEY_ASTRAZENECA_SECOND = '7108'
+
+class DoctolibFR(Doctolib):
+    BASEURL = 'https://www.doctolib.fr'
+    FR_keys = DoctolibFR_KEYS
+
     vaccine_motives = {
         KEY_PFIZER: 'Pfizer',
         KEY_PFIZER_SECOND: '2de.*Pfizer',


### PR DESCRIPTION
Hello Team,

Note: I am applying the aggregates pattern to this open source code as part of a **school project**.

The aggregates pattern helps make a simpler design to code and keep the classes simple. 

I applied aggregation to the `KEYS` in both DoctolibDE and DoctolibFR to separate them into their own dedicated classes.