### PR TITLE
support CLI arguments via config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/docto.config
+
 __pycache__
 *.pyc
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,25 @@ Further optional arguments:
 --code CODE           2FA code
 ```
 
+For easier reuse, it is possible to provide the arguments in a config file containing each parameter in a separate line.
+
+```
+./doctoshotgun.py @filename
+```
+
+> Beware: argument name and value need to go to separate lines, values have no quotes
+
+Example `docto.config`:
+```
+fr
+paris
+roger.philibert@gmail.com
+--center
+Centre de Vaccination Covid 19 - Ville de Paris
+--center
+Centre de Vaccination du 7eme arrondissement de Paris - Gymnase Camou
+```
+
 ### With Docker
 
 Build the image:

--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -626,7 +626,8 @@ class Application:
         }
 
         parser = argparse.ArgumentParser(
-            description="Book a vaccine slot on Doctolib")
+            description="Book a vaccine slot on Doctolib",
+            fromfile_prefix_chars='@')
         parser.add_argument('--debug', '-d', action='store_true',
                             help='show debug information')
         parser.add_argument('--pfizer', '-z', action='store_true',

--- a/test_cli_args.py
+++ b/test_cli_args.py
@@ -63,6 +63,23 @@ def test_center_exclude_arg_should_filter_excluded_centers(MockDoctolibDE, tmp_p
         assert call_args_list.args[0]['city'] == city
 
 
+@responses.activate
+@patch('doctoshotgun.DoctolibDE')
+def test_config_file_should_be_used(MockDoctolibDE, tmp_path):
+    """
+    Check that config file is used corrrectly
+    """
+    # prepare
+    mock_doctolib_de = get_mocked_doctolib(MockDoctolibDE)
+
+    # call
+    call_application_without_default_args(
+        cli_args=['@test_fixtures/docto.config'])
+
+    # assert
+    assert mock_doctolib_de.try_to_book.called
+
+
 def get_mocked_doctolib(MockDoctolibDE):
     mock_doctolib_de = MagicMock(wraps=DoctolibDE)
     MockDoctolibDE.return_value = mock_doctolib_de
@@ -88,4 +105,11 @@ def call_application(city, cli_args=[]):
     assert 0 == Application.main(
         Application(),
         cli_args=["de", city, "roger.phillibert@gmail.com", "1234"] + cli_args
+    )
+
+
+def call_application_without_default_args(cli_args):
+    assert 0 == Application.main(
+        Application(),
+        cli_args=cli_args
     )

--- a/test_fixtures/docto.config
+++ b/test_fixtures/docto.config
@@ -1,0 +1,4 @@
+de
+koln
+roger.phillibert@gmail.com
+1234


### PR DESCRIPTION
I found a quick way of supporting a config file with `fromfile-prefix-chars` in the [argparse ](https://docs.python.org/3/library/argparse.html#fromfile-prefix-chars) library.
Would have preferred a nicely structured YAML file, but this was a quick win, so I couldn't resist.

Fixes #84.