### PR TITLE
Singleton creational pattern applied to prevent more than one Application class object from being created

### DIFF
--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -602,6 +602,21 @@ class DoctolibFR(Doctolib):
 
 
 class Application:
+    __instance = None
+
+    @staticmethod
+    def get_instance():
+        if Application.__instance is None:
+            Application()
+
+        return Application.__instance
+
+    def __init__(self):
+        if Application.__instance is None:
+            Application.__instance = self
+        else:
+            raise Exception("The application class constructor can not be called more than once, as it is a Singleton")
+
     @classmethod
     def create_default_logger(cls):
         # stderr logger
@@ -860,7 +875,7 @@ class Application:
 
 if __name__ == '__main__':
     try:
-        sys.exit(Application().main())
+        sys.exit(Application.get_instance().main())
     except KeyboardInterrupt:
         print('Abort.')
         sys.exit(1)


### PR DESCRIPTION
**EECS 3311- Prof. Maleknaz Nayebi - Course Project- Creational Design Pattern - York University**
The Singleton pattern was applied to "Application class" in "doctoshotgun.py".
This prevents from multiple objects of "Application" class with different configuration from being created.
As the configuration should only be provided by user via command line arguments once when application is executed.