### PR TITLE
Attempt at fixing tests broken because of new StatesMixin

### DIFF
--- a/test_cli_args.py
+++ b/test_cli_args.py
@@ -81,6 +81,9 @@ def get_mocked_doctolib(MockDoctolibDE):
 
     mock_doctolib_de.try_to_book.return_value = True
 
+    mock_doctolib_de.load_state.return_value = {}
+    mock_doctolib_de.dump_state.return_value = None
+
     return mock_doctolib_de
 
 


### PR DESCRIPTION
Note: this does not necessarily mean that the load_state and dump_state
methods will work on DoctolibDE. I just made the `dump_state` method do nothing,
and `load_state` return `{}`.

This means that `load_state` in the `StatesMixin` is not called.

I am pretty sure that this should not be merged as is.