### PR TITLE
Adding support for proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Further optional arguments:
 --end-date END_DATE   last date on which you want to book the first slot (format should be DD/MM/YYYY)
 --dry-run             do not really book the slot
 --code CODE           2FA code
+--proxy PROXY, -P PROXY
+                      configure a network proxy to use
 ```
 
 ### With Docker

--- a/doctoshotgun.py
+++ b/doctoshotgun.py
@@ -710,6 +710,8 @@ class Application:
         parser.add_argument('username', help='Doctolib username')
         parser.add_argument('password', nargs='?', help='Doctolib password')
         parser.add_argument('--code', type=str, default=None, help='2FA code')
+        parser.add_argument('--proxy', '-P', type=str, default=None,
+                            help='define a proxy to use')
         args = parser.parse_args(cli_args if cli_args else sys.argv[1:])
 
         if args.debug:
@@ -724,6 +726,10 @@ class Application:
 
         docto = doctolib_map[args.country](
             args.username, args.password, responses_dirname=responses_dirname)
+
+        if args.proxy:
+            docto.PROXIES = {'https': args.proxy}
+
         docto.load_state(self.load_state())
 
         try:


### PR DESCRIPTION
As others, I have ran into (temporary? Several hours so far) blacklisting of my IP (cf. [here](/rbignon/doctoshotgun/issues/296)).
The use of a proxy helped work around that blocking.

But on windows, the corresponding environment variables have no effect.
So here is a new `--proxy PROXY` parameter to explicitely define a proxy for the HTTPS protocole.

Note that the use of some proxy schemes (e.g. "socks5://") require additional package (e.g. "PySocks"). I don't know if that's worth mentioning in the doc though. It is reported at runtime on the output.